### PR TITLE
Add lcdproc plugin for SoundGraph Imon VFD displays.

### DIFF
--- a/plugins/vdr-lcdproc/50-lcdproc.conf
+++ b/plugins/vdr-lcdproc/50-lcdproc.conf
@@ -1,0 +1,6 @@
+[lcdproc]
+#--host <host>
+#    LCDproc host (default=localhost)
+
+#--port <port>
+#    LCDproc port (default=13666)

--- a/plugins/vdr-lcdproc/92-lcdproc.rules
+++ b/plugins/vdr-lcdproc/92-lcdproc.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="15c2", ATTR{idProduct}=="ffdc", GROUP="vdr"

--- a/plugins/vdr-lcdproc/PKGBUILD
+++ b/plugins/vdr-lcdproc/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Christopher Reimer <vdr4arch[at]creimer[dot]net>
+pkgname=vdr-lcdproc
+pkgver=v.0.0.10_jw9_9_g0c54897
+_gitver=0c548975b2d66d860180c79d58235a8923641a0c
+_vdrapi=2.1.9
+pkgrel=1
+pkgdesc="Output to LCD modules that are supported by LCDproc"
+url="http://projects.vdr-developer.org/projects/plg-lcdproc"
+arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
+license=('GPL2')
+depends=("vdr-api=${_vdrapi}")
+makedepends=('git')
+optdepends=('lcdproc: to use local displays')
+_plugname=$(echo $pkgname | sed 's/vdr-//g')
+source=("git://projects.vdr-developer.org/vdr-plugin-lcdproc.git#commit=$_gitver"
+        "50-$_plugname.conf"
+        '92-lcdproc.rules')
+backup=("etc/vdr/conf.avail/50-$_plugname.conf")
+md5sums=('SKIP'
+         '0221e0b8878d56e3a057ac37a9c853cf'
+         '67d1e0de8e90e0d4e9e977ddfd952442')
+
+pkgver() {
+  cd "${srcdir}/vdr-plugin-$_plugname"
+  git describe --tags | sed 's/-/_/g'
+}
+
+build() {
+  cd "${srcdir}/vdr-plugin-$_plugname"
+  make
+}
+
+package() {
+  cd "${srcdir}/vdr-plugin-$_plugname"
+  make DESTDIR="$pkgdir" install
+
+  install -Dm644 "$srcdir/92-lcdproc.rules" "$pkgdir/usr/lib/udev/rules.d/92-lcdproc.rules"
+
+  install -Dm644 "$srcdir/50-$_plugname.conf" "$pkgdir/etc/vdr/conf.avail/50-$_plugname.conf"
+}


### PR DESCRIPTION
Reason: The imonlcd plugin doesn't support VFD displays.