### PR TITLE
vdr-rpihddevice - fix compiling with gcc 6.1.1

### DIFF
--- a/plugins/vdr-rpihddevice/PKGBUILD
+++ b/plugins/vdr-rpihddevice/PKGBUILD
@@ -3,9 +3,9 @@
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-rpihddevice
 pkgver=1.0.0
-_gitver=f4b9c55f3e4eb6e60aceba43d97f611020dc0361
+_gitver=00af2c0eb2b86249b5aa680fccd6d3239a05e8f8
 _vdrapi=2.2.0
-pkgrel=2
+pkgrel=1
 pkgdesc="Output device for Raspberry Pi"
 url="http://projects.vdr-developer.org/projects/plg-rpihddevice"
 arch=('armv6h' 'armv7h')

--- a/plugins/vdr-rpihddevice/PKGBUILD
+++ b/plugins/vdr-rpihddevice/PKGBUILD
@@ -2,7 +2,7 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-rpihddevice
-pkgver=1.0.0
+pkgver=1.0.0.r27.g00af2c0
 _gitver=00af2c0eb2b86249b5aa680fccd6d3239a05e8f8
 _vdrapi=2.2.0
 pkgrel=1
@@ -14,9 +14,11 @@ depends=('ffmpeg' 'mesa' 'raspberrypi-firmware-tools' "vdr-api=${_vdrapi}")
 makedepends=('git')
 _plugname=${pkgname//vdr-/}
 source=("git://projects.vdr-developer.org/vdr-plugin-rpihddevice.git#commit=$_gitver"
+        "gcc6-fixes01.patch"
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
 md5sums=('SKIP'
+         'cee9569e8a827cca79188a5ce27dce1c'
          '60564c9e26e39aedf8a932d8093f999a')
 
 pkgver() {
@@ -37,6 +39,11 @@ pkgver() {
 build() {
   cd "${srcdir}/vdr-plugin-${_plugname}"
   make
+}
+
+prepare() {
+  cd "${srcdir}/vdr-plugin-${_plugname}"
+  patch -p0 -i "$srcdir/gcc6-fixes01.patch"
 }
 
 package() {

--- a/plugins/vdr-rpihddevice/gcc6-fixes01.patch
+++ b/plugins/vdr-rpihddevice/gcc6-fixes01.patch
@@ -1,0 +1,87 @@
+--- Makefile	2016-05-19 10:57:44.314733555 +0200
++++ Makefile	2016-05-19 11:01:07.804973249 +0200
+@@ -50,6 +50,7 @@ SOFILE = libvdr-$(PLUGIN).so
+ DEFINES += -DPLUGIN_NAME_I18N='"$(PLUGIN)"'
+ DEFINES += -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM
+ DEFINES += -Wno-psabi -Wno-write-strings -fpermissive
++DEFINES += -D__STL_CONFIG_H
+ 
+ CXXFLAGS += -D__STDC_CONSTANT_MACROS
+
+ 
+--- tools.c	2016-05-19 11:07:27.934749187 +0200
++++ tools.c	2016-05-19 11:11:48.744301670 +0200
+@@ -20,6 +20,7 @@
+ #include <limits.h>
+ #include <vdr/tools.h>
+ #include "tools.h"
++#include <algorithm>
+ 
+ /*
+  * ffmpeg's implementation for rational numbers:
+@@ -32,7 +33,7 @@ cRational::cRational(double d) :
+ 	int exp;
+ 	frexp(d, &exp);
+ 
+-	den = 1LL << (29 - max(exp - 1, 0));
++	den = 1LL << (29 - std::max(exp - 1, 0));
+ 	num = floor(d * den + 0.5);
+ 
+ 	Reduce(INT_MAX);
+@@ -62,7 +63,7 @@ bool cRational::Reduce(int max)
+ 			if (a1.num)
+ 				x = (max - a0.num) / a1.num;
+ 			if (a1.den)
+-				x = min(x, (max - a0.den) / a1.den);
++				x = std::min(x, (max - a0.den) / a1.den);
+ 			if (den * (2 * x * a1.den + a0.den) > num * a1.den)
+ 				a1 = cRational(x * a1.num + a0.num, x * a1.den + a0.den);
+ 			break;
+
+
+--- ovgosd.c	2016-05-19 11:14:30.153955031 +0200
++++ ovgosd.c	2016-05-19 11:23:23.642600743 +0200
+@@ -1209,14 +1209,14 @@ public:
+ 			if (m_alignment & taLeft)
+ 			{
+ 				if (m_alignment & taBorder)
+-					offsetX += max(height / TEXT_ALIGN_BORDER, 1.0f);
++					offsetX += std::max(height / TEXT_ALIGN_BORDER, 1.0f);
+ 			}
+ 			else if (m_alignment & taRight)
+ 			{
+ 				if (width < m_w)
+ 					offsetX += m_w - width;
+ 				if (m_alignment & taBorder)
+-					offsetX -= max(height / TEXT_ALIGN_BORDER, 1.0f);
++					offsetX -= std::max(height / TEXT_ALIGN_BORDER, 1.0f);
+ 			}
+ 			else
+ 			{
+@@ -1592,8 +1592,8 @@ public:
+ 
+ 	virtual bool Execute(cEgl *egl)
+ 	{
+-		int w = min(m_w, vgGeti(VG_MAX_IMAGE_WIDTH));
+-		int h = min(m_h, vgGeti(VG_MAX_IMAGE_HEIGHT));
++		int w = std::min(m_w, vgGeti(VG_MAX_IMAGE_WIDTH));
++		int h = std::min(m_h, vgGeti(VG_MAX_IMAGE_HEIGHT));
+ 
+ 		if (w <= 0 || h <= 0)
+ 			return true;
+@@ -2375,11 +2375,11 @@ public:
+ 		{
+ 			ELOG("[OpenVG] cannot allocate pixmap of %dpx x %dpx, "
+ 					"clipped to %dpx x %dpx!", width, height,
+-					min(width, m_ovg->MaxImageSize().Width()),
+-					min(height, m_ovg->MaxImageSize().Height()));
++					std::min(width, m_ovg->MaxImageSize().Width()),
++					std::min(height, m_ovg->MaxImageSize().Height()));
+ 
+-			width = min(width, m_ovg->MaxImageSize().Width());
+-			height = min(height, m_ovg->MaxImageSize().Height());
++			width = std::min(width, m_ovg->MaxImageSize().Width());
++			height = std::min(height, m_ovg->MaxImageSize().Height());
+ 		}
+ #endif
+ 		// create pixel buffer and wait until command has been completed


### PR DESCRIPTION
This does:
Update vdr-rpihddevice (1.0.3 Revision 00af2c0e)
adds patch to fix compiling with gcc 6.1.1-1.1

Proof:
Finished making: `vdr-rpihddevice 1.0.0.r27.g00af2c0-1 (Sat May 28 11:15:14 CEST 2016)`

More:
[vdr-portal](http://www.vdr-portal.de/board16-video-disk-recorder/board55-vdr-plugins/129052-rpihddevice-patch-zum-kompilieren-mit-gcc6/)