### PR TITLE
Bump to version 1.0.5

### DIFF
--- a/plugins/vdr-ddci2/.SRCINFO
+++ b/plugins/vdr-ddci2/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vdr-ddci2
 	pkgdesc = Support for stand alone CI by Digital Devices for VDR 2.1.6 and higher.
-	pkgver = 1.0.1
+	pkgver = 1.0.5
 	pkgrel = 1
 	url = https://github.com/jasmin-j/vdr-plugin-ddci2
 	arch = x86_64
@@ -13,7 +13,7 @@ pkgbase = vdr-ddci2
 	depends = gcc-libs
 	depends = vdr-api=2.2.0
 	backup = etc/vdr/conf.avail/50-ddci2.conf
-	source = git+https://github.com/jasmin-j/vdr-plugin-ddci2.git#commit=056fd68990eab7610fa421b384262edc79c3f13c
+	source = git+https://github.com/jasmin-j/vdr-plugin-ddci2.git#commit=a5a7ab1cb6be3ebddb8af77cc18313d75404ed81
 	source = 50-ddci2.conf
 	md5sums = SKIP
 	md5sums = 5dc8a287efe1419aaf1162cb6a6f28f3


### PR DESCRIPTION
Bump version to 1.0.5 to reflect changes from https://github.com/VDR4Arch/vdr4arch/pull/167