### PR TITLE
Update vdr-dvbapi (latest git)

### DIFF
--- a/plugins/vdr-dvbapi/.SRCINFO
+++ b/plugins/vdr-dvbapi/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-dvbapi
 	pkgdesc = A bridge between VDR and OScam.
-	pkgver = 2.2.4
-	pkgrel = 3
+	pkgver = 2.2.4_4_g7d51cc4
+	pkgrel = 1
 	epoch = 1
 	url = https://github.com/manio/vdr-plugin-dvbapi
 	arch = x86_64
@@ -16,10 +16,8 @@ pkgbase = vdr-dvbapi
 	depends = openssl
 	depends = vdr-api=2.4.0
 	backup = etc/vdr/conf.avail/50-dvbapi.conf
-	source = https://github.com/manio/vdr-plugin-dvbapi/archive/v2.2.4.tar.gz
-	source = https://github.com/manio/vdr-plugin-dvbapi/commit/7d51cc457823156d446d06c6ae40f850958fa735.diff
-	sha256sums = 0014cd9fbf40d10f630c4aa9b2e60c9dca44d4cdab27529da3e47be9a9c01e13
-	sha256sums = f82b647e34048e983a9a3254524443f92c19a3d003387c4c430375f0be7a3a76
+	source = git+https://github.com/manio/vdr-plugin-dvbapi.git#commit=7d51cc457823156d446d06c6ae40f850958fa735
+	sha256sums = SKIP
 
 pkgname = vdr-dvbapi
 

--- a/plugins/vdr-dvbapi/PKGBUILD
+++ b/plugins/vdr-dvbapi/PKGBUILD
@@ -2,10 +2,11 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-dvbapi
-pkgver=2.2.4
+pkgver=2.2.4_4_g7d51cc4
 epoch=1
+_gitver=7d51cc457823156d446d06c6ae40f850958fa735
 _vdrapi=2.4.0
-pkgrel=3
+pkgrel=1
 pkgdesc="A bridge between VDR and OScam."
 url="https://github.com/manio/vdr-plugin-dvbapi"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
@@ -13,25 +14,23 @@ license=('GPL2')
 depends=('gcc-libs' 'libdvbcsa' 'openssl' "vdr-api=${_vdrapi}")
 makedepends=('git')
 _plugname=${pkgname//vdr-/}
-source=("https://github.com/manio/vdr-plugin-dvbapi/archive/v$pkgver.tar.gz"
-        "https://github.com/manio/vdr-plugin-dvbapi/commit/7d51cc457823156d446d06c6ae40f850958fa735.diff")
+source=("git+${url}.git#commit=${_gitver}")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('0014cd9fbf40d10f630c4aa9b2e60c9dca44d4cdab27529da3e47be9a9c01e13'
-            'f82b647e34048e983a9a3254524443f92c19a3d003387c4c430375f0be7a3a76')
+sha256sums=('SKIP')
 
-prepare() {
-  cd "${srcdir}/vdr-plugin-${_plugname}-${pkgver}"
-  patch -p1 -i "$srcdir/7d51cc457823156d446d06c6ae40f850958fa735.diff"
+pkgver() {
+  cd "${srcdir}/vdr-plugin-${_plugname}"
+  git describe --tags | sed 's/-/_/g;s/v//'
 }
 
 build() {
-  cd "${srcdir}/vdr-plugin-${_plugname}-${pkgver}"
+  cd "${srcdir}/vdr-plugin-${_plugname}"
   sed -i 's/ -fdiagnostics-color=auto//g' Makefile
   make LIBDVBCSA=1
 }
 
 package() {
-  cd "${srcdir}/vdr-plugin-${_plugname}-${pkgver}"
+  cd "${srcdir}/vdr-plugin-${_plugname}"
   make LIBDVBCSA=1 DESTDIR="$pkgdir" install
 
   mkdir -p "$pkgdir/etc/vdr/conf.avail"


### PR DESCRIPTION
The 2.2.4 version is not compatible with current vdr stable version. The plugin segfaults when trying to decode channels. Use git version which already has necessary adjustments.