### PR TITLE
vdr-osdteletext: package teletext2 font and fix blank lines

### DIFF
--- a/fonts/ttf-teletext2/.SRCINFO
+++ b/fonts/ttf-teletext2/.SRCINFO
@@ -1,0 +1,14 @@
+pkgbase = ttf-teletext2
+	pkgdesc = TrueType font for renderng special graphic characters used in Teletext
+	pkgver = 1.0
+	pkgrel = 1
+	url = https://projects.vdr-developer.org/projects/plg-osdteletext
+	arch = any
+	license = GPL2
+	depends = fontconfig
+	depends = xorg-fonts-encodings
+	depends = xorg-font-utils
+	source = https://projects.vdr-developer.org/projects/plg-osdteletext/repository/revisions/b2df8095dee3bec5f0a5cf9a363b364512ed3df9/entry/teletext2.ttf
+	md5sums = ddc338f8165f93d7b7ee722f59ec8be0
+
+pkgname = ttf-teletext2

--- a/fonts/ttf-teletext2/PKGBUILD
+++ b/fonts/ttf-teletext2/PKGBUILD
@@ -1,0 +1,19 @@
+# This PKGBUILD is part of the VDR4Arch project [https://github.com/vdr4arch]
+
+# Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
+pkgname=ttf-teletext2
+pkgver=1.0
+_gitver=b2df8095dee3bec5f0a5cf9a363b364512ed3df9
+pkgrel=1
+pkgdesc="TrueType font for renderng special graphic characters used in Teletext"
+arch=('any')
+license=('GPL2')
+url="https://projects.vdr-developer.org/projects/plg-osdteletext"
+depends=('fontconfig' 'xorg-fonts-encodings' 'xorg-font-utils')
+source=("${url}/repository/revisions/${_gitver}/entry/teletext2.ttf")
+md5sums=('ddc338f8165f93d7b7ee722f59ec8be0')
+
+package() {
+	mkdir -p ${pkgdir}/usr/share/fonts/TTF
+	install -m644 ${srcdir}/teletext2.ttf ${pkgdir}/usr/share/fonts/TTF/
+}

--- a/plugins/vdr-osdteletext/.SRCINFO
+++ b/plugins/vdr-osdteletext/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-osdteletext
 	pkgdesc = Displays teletext pages directly on VDR's OSD
 	pkgver = 0.9.7
-	pkgrel = 1
+	pkgrel = 2
 	url = http://projects.vdr-developer.org/projects/plg-osdteletext
 	arch = x86_64
 	arch = i686
@@ -11,10 +11,13 @@ pkgbase = vdr-osdteletext
 	license = GPL2
 	depends = gcc-libs
 	depends = vdr-api=2.4.0
+	optdepends = ttf-teletext2: renderng special graphic characters used in Teletext
 	backup = etc/vdr/conf.avail/50-osdteletext.conf
 	source = http://projects.vdr-developer.org/git/vdr-plugin-osdteletext.git/snapshot/vdr-plugin-osdteletext-0.9.7.tar.bz2
+	source = remove-blank-lines.patch::https://www.vdr-portal.de/index.php?attachment/41771
 	source = 50-osdteletext.conf
 	md5sums = 3cc9318b3b5d63884320b57e2268648c
+	md5sums = 14d8bd880d82f3a86705ca94ed8aac84
 	md5sums = 4e47fd8f77cea06d30e07486b7fd9d6e
 
 pkgname = vdr-osdteletext

--- a/plugins/vdr-osdteletext/PKGBUILD
+++ b/plugins/vdr-osdteletext/PKGBUILD
@@ -4,18 +4,26 @@
 pkgname=vdr-osdteletext
 pkgver=0.9.7
 _vdrapi=2.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Displays teletext pages directly on VDR's OSD"
 url="http://projects.vdr-developer.org/projects/plg-osdteletext"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
 license=('GPL2')
 depends=('gcc-libs' "vdr-api=${_vdrapi}")
+optdepends=('ttf-teletext2: renderng special graphic characters used in Teletext')
 _plugname=${pkgname//vdr-/}
 source=("http://projects.vdr-developer.org/git/vdr-plugin-$_plugname.git/snapshot/vdr-plugin-$_plugname-$pkgver.tar.bz2"
+        'remove-blank-lines.patch::https://www.vdr-portal.de/index.php?attachment/41771'
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
 md5sums=('3cc9318b3b5d63884320b57e2268648c'
+         '14d8bd880d82f3a86705ca94ed8aac84'
          '4e47fd8f77cea06d30e07486b7fd9d6e')
+
+prepare() {
+  cd "${srcdir}/vdr-plugin-${_plugname}-${pkgver}"
+  patch -p1 -i "${srcdir}/remove-blank-lines.patch"
+}
 
 build() {
   cd "${srcdir}/vdr-plugin-${_plugname}-${pkgver}"


### PR DESCRIPTION
Package the teletext2.ttf font, on which osdteletext relies now for displaying characters. This follows the request in issue #175. The update also incorporates fix for characters alignment which is seen as blank horizontal lines.