### PR TITLE
Update vdr-skinflatplus (latest git)

### DIFF
--- a/plugins/vdr-skinflatplus/.SRCINFO
+++ b/plugins/vdr-skinflatplus/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-skinflatplus
 	pkgdesc = Simple and slim skin for VDR
-	pkgver = 0.6.0
-	pkgrel = 2
+	pkgver = 0.6.0.r12.g5a8c1819
+	pkgrel = 1
 	url = http://projects.vdr-developer.org/projects/plg-skinflatplus
 	arch = x86_64
 	arch = i686
@@ -18,7 +18,7 @@ pkgbase = vdr-skinflatplus
 	backup = var/lib/vdr/plugins/skinflatplus/configs/MV_default
 	backup = var/lib/vdr/plugins/skinflatplus/configs/default
 	backup = var/lib/vdr/plugins/skinflatplus/configs/fnu_default
-	source = git://projects.vdr-developer.org/skin-flatplus.git#commit=cd60fe82b3c0dd03b92b10cdc3135a0ef57f835a
+	source = git://projects.vdr-developer.org/skin-flatplus.git#commit=5a8c1819d963bc78c317b98dd2e77be68bad1549
 	source = 50-skinflatplus.conf
 	md5sums = SKIP
 	md5sums = 878594e0f5af2ab308e6ab86a9bf0136

--- a/plugins/vdr-skinflatplus/PKGBUILD
+++ b/plugins/vdr-skinflatplus/PKGBUILD
@@ -2,10 +2,10 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-skinflatplus
-pkgver=0.6.0
-_gitver=cd60fe82b3c0dd03b92b10cdc3135a0ef57f835a
+pkgver=0.6.0.r12.g5a8c1819
+_gitver=5a8c1819d963bc78c317b98dd2e77be68bad1549
 _vdrapi=2.4.0
-pkgrel=2
+pkgrel=1
 pkgdesc="Simple and slim skin for VDR"
 url="http://projects.vdr-developer.org/projects/plg-skinflatplus"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')


### PR DESCRIPTION
Current VDR has changed locking mechanism which is incompatible with present version of skinflatplus. One of the symptoms of this is that only current and past EPG events are displayed in Schedule menu. There may be other issues which I didn't spot.
Hence update package to latest commit which has proper adjustments.