### PR TITLE
vdr-live: replace VLC NPAPI support with ability to play stream by external media player

### DIFF
--- a/plugins/vdr-live/.SRCINFO
+++ b/plugins/vdr-live/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-live
 	pkgdesc = Adds the possibility to control VDR and some of it's plugins by a web interface.
 	pkgver = 2.3.1
-	pkgrel = 2
+	pkgrel = 3
 	epoch = 1
 	url = http://projects.vdr-developer.org/projects/plg-live
 	install = vdr-live.install
@@ -12,6 +12,7 @@ pkgbase = vdr-live
 	arch = armv7h
 	license = GPL2
 	makedepends = git
+	makedepends = patchutils
 	depends = pcre
 	depends = tntnet
 	depends = vdr-api=2.4.0
@@ -19,8 +20,12 @@ pkgbase = vdr-live
 	optdepends = vdr-streamdev: Stream live TV
 	backup = etc/vdr/conf.avail/50-live.conf
 	source = git://projects.vdr-developer.org/vdr-plugin-live.git#commit=e582514ede475574842b44ca6792335ff141172d
+	source = https://projects.vdr-developer.org/attachments/download/2186/v2-0004-Add-ability-to-play-stream-by-external-media-player.patch
+	source = https://projects.vdr-developer.org/attachments/download/2187/0005-Remove-support-for-VLC-NPAPI-plugin-and-replace-it-w.patch
 	source = 50-live.conf
 	md5sums = SKIP
+	md5sums = 14152d6ddc14d5ec39473f92ca1c1f78
+	md5sums = ea8187d1e51fbc1a48767ac6eb0f33d2
 	md5sums = 563961eb90d9f2b3d2a0a34472ef51ee
 
 pkgname = vdr-live

--- a/plugins/vdr-live/PKGBUILD
+++ b/plugins/vdr-live/PKGBUILD
@@ -6,7 +6,7 @@ pkgver=2.3.1
 epoch=1
 _gitver=e582514ede475574842b44ca6792335ff141172d
 _vdrapi=2.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Adds the possibility to control VDR and some of it's plugins by a web interface."
 url="http://projects.vdr-developer.org/projects/plg-live"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
@@ -14,14 +14,24 @@ license=('GPL2')
 depends=('pcre' 'tntnet' "vdr-api=${_vdrapi}")
 optdepends=('vdr-epgsearch: Manage searchtimers'
             'vdr-streamdev: Stream live TV')
-makedepends=('git')
+makedepends=('git' 'patchutils')
 install="$pkgname.install"
 _plugname=${pkgname//vdr-/}
 source=("git://projects.vdr-developer.org/vdr-plugin-live.git#commit=$_gitver"
+        'https://projects.vdr-developer.org/attachments/download/2186/v2-0004-Add-ability-to-play-stream-by-external-media-player.patch'
+        'https://projects.vdr-developer.org/attachments/download/2187/0005-Remove-support-for-VLC-NPAPI-plugin-and-replace-it-w.patch'
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
 md5sums=('SKIP'
+         '14152d6ddc14d5ec39473f92ca1c1f78'
+         'ea8187d1e51fbc1a48767ac6eb0f33d2'
          '563961eb90d9f2b3d2a0a34472ef51ee')
+
+prepare() {
+  cd "${srcdir}/vdr-plugin-${_plugname}"
+  filterdiff -x '*.po' ${srcdir}/v2-0004-Add-ability-to-play-stream-by-external-media-player.patch | git apply -
+  filterdiff -x '*.po' ${srcdir}/0005-Remove-support-for-VLC-NPAPI-plugin-and-replace-it-w.patch | git apply -
+}
 
 pkgver() {
   cd "${srcdir}/vdr-plugin-${_plugname}"


### PR DESCRIPTION
Hi
This adds pink play button (beside the yellow one), which serves playlist with stream link, playable by majority of media players. Should work with every browser allowing to open files instead of only downloading them.
I've sent this extension to upstream repo https://projects.vdr-developer.org/issues/2573, but I don't know if or when current maintainer will commit it, but I still think it's useful change, since most browsers don't support NPAPI plugins any more.

![vdr-live-m3u-cut](https://user-images.githubusercontent.com/1316161/55292373-58df6980-53ea-11e9-9261-74b7e76d229f.png)
