### PR TITLE
vdr-xineliboutput: fix package version creation

### DIFF
--- a/plugins/vdr-xineliboutput/PKGBUILD
+++ b/plugins/vdr-xineliboutput/PKGBUILD
@@ -18,7 +18,7 @@ md5sums=('SKIP'
 
 pkgver() {
   cd "${srcdir}/$pkgbase"
-  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+  git describe --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {


### PR DESCRIPTION
Remove the --long option, since it's printing unneeded cruft for stable tag. For version between the tags, the needed information is printed with --tags anyway.