### PR TITLE
Enable Travis CI

### DIFF
--- a/.ci/genindex.sh
+++ b/.ci/genindex.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+target="$1"
+repo="$2"
+
+create_index() {
+	index=$(ls --color=never --group-directories-first -1 -p --hide=index.html $1 | awk '{print "<a href=\""$1"\">"$1"</a>"}')
+
+	echo "<html>
+<head><title>Index of /${r}${d}</title></head>
+<body>
+<h1>Index of /${r}${d}</h1><hr><pre>
+<a href="../">../</a>
+${index}
+</pre><hr></body>
+</html>" > index.html
+}
+
+cd ${target}
+
+d=${repo}/
+create_index
+r=${d}
+
+for d in */; do
+	(cd ${d}
+	create_index)
+done

--- a/.ci/mkrepo.sh
+++ b/.ci/mkrepo.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+builduser="${1}"
+reposrc="${2}"
+alarch="${3}"
+
+alchroot=/home/${builduser}/abs/${alarch}
+reponame=$(basename ${reposrc})
+
+setup_x86_64_chroot() {
+	distro=archlinux
+
+	wget -nc -P /home/${builduser}/ -r -l 1 -nd -A 'archlinux-bootstrap-*-x86_64.tar.gz' 'https://mirrors.ocf.berkeley.edu/archlinux/iso/latest/'
+	tar -x -z --strip 1 -C /home/${builduser}/abs/${alarch}/ -f /home/${builduser}/archlinux-bootstrap-*-x86_64.tar.gz
+	printf "Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch\n" >> ${alchroot}/etc/pacman.d/mirrorlist
+}
+
+mkdir -p ${alchroot}
+mount --bind ${alchroot} ${alchroot}
+setup_${alarch}_chroot
+
+mount -t proc /proc ${alchroot}/proc
+mount --rbind /dev ${alchroot}/dev
+mount --rbind /sys ${alchroot}/sys
+cp -f /etc/resolv.conf ${alchroot}/etc/
+printf "en_US.UTF-8 UTF-8\n" > ${alchroot}/etc/locale.gen
+chroot ${alchroot} /bin/bash -c \
+	"source /etc/profile; \
+	pacman-key --init; \
+	pacman-key --populate ${distro}; \
+	pacman -S -y -u --noconfirm base-devel; \
+	locale-gen; \
+	groupadd -g 2000 ${builduser}; \
+	useradd -u 2000 -g 2000 -m -G wheel -s /bin/bash ${builduser}"
+printf "%%wheel ALL=(ALL) NOPASSWD: ALL\n" > ${alchroot}/etc/sudoers.d/wheel
+
+mkdir -p ${alchroot}/home/${builduser}/{repo,src,${reponame}}
+mkdir -p /home/${builduser}/{repo/${alarch},src}
+mount --bind /home/${builduser}/repo ${alchroot}/home/${builduser}/repo
+mount --bind /home/${builduser}/src ${alchroot}/home/${builduser}/src
+mount --bind ${reposrc} ${alchroot}/home/${builduser}/${reponame}
+printf "MAKEFLAGS='-j2'\nPACKAGER=\"${reponame} build bot\"\nSRCDEST=/home/${builduser}/src\n" >> ${alchroot}/etc/makepkg.conf
+
+wget -q -nc -P ${alchroot}/usr/bin 'https://github.com/M-Reimer/repo-make/raw/master/repo-make'
+chmod 755 ${alchroot}/usr/bin/repo-make
+printf "BUILDUSER=${builduser}\n" > ${alchroot}/etc/repo-make.conf
+chroot ${alchroot} /bin/bash -c \
+	"source /etc/profile; \
+	printenv | sort; \
+	repo-make -V -C /home/${builduser}/${reponame} -t /home/${builduser}/repo/${alarch}"
+
+exit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+branches:
+  only:
+  - master
+
+arch:
+  - amd64
+
+os: linux
+
+dist: bionic
+
+env:
+  - REPONAME=vdr4arch ALARCH=x86_64
+
+language: generic
+
+git:
+  quiet: true
+
+cache:
+  directories:
+    - $HOME/src
+
+before_script:
+  - sudo mkdir -p /run/shm/
+  - git clone https://github.com/VDR4Arch/vdr4arch.git --branch gh-pages --single-branch $HOME/repo || true
+  - rm -fR $HOME/repo/.git
+
+script:
+  - sudo ./.ci/mkrepo.sh $USER $TRAVIS_BUILD_DIR $ALARCH
+
+before_deploy:
+  - sudo chown -R $USER:$USER $HOME/repo
+  - ./.ci/genindex.sh $HOME/repo $REPONAME
+
+deploy:
+  provider: pages
+  token: $GITHUB_TOKEN
+  skip_cleanup: true
+  local_dir: $HOME/repo/
+  on:
+    repo: $TRAVIS_REPO_SLUG
+    branch: master


### PR DESCRIPTION
Hi Manuel.
These are the changes that piqued Your interest in my repo. As explained, this allows to test the current state of repository for build failures and a bonus to create repository with built packages.
Since You last saw it I cleaned it up a bit, removed other architectures, as that didn't work, dropped `arch-chroot` wrapper and switched to straight `chroot` usage.

If privacy is the concern (for allowing Travis CI to access repository), it's still safe to commit these changes, as without connecting to CI provider, other users forking this repository could do that and have their own VDR4Arch repository and build tests.

On the side note. I You will decide to subscribe to Travis CI, initial build could fail few times because of source download issues and it would need a restart in CI provider dashboard. After first success the packages source will be cached and restored on each build so those type of fallouts won't occur very frequently.