### PR TITLE
dfatmo: migrate from python2 to python3

### DIFF
--- a/plugins/vdr-dfatmo/.SRCINFO
+++ b/plugins/vdr-dfatmo/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dfatmo
 	pkgver = 0.5.0
-	pkgrel = 6
+	pkgrel = 7
 	epoch = 1
 	url = https://github.com/durchflieger/dfatmo
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = dfatmo
 	arch = armv7h
 	license = GPL2
 	makedepends = libusb
-	makedepends = python2
+	makedepends = python
 	makedepends = vdr-api=2.4.6
 	makedepends = zip
 	source = dfatmo-0.5.0.tar.gz::https://github.com/durchflieger/dfatmo/archive/v0.5.0.tar.gz
@@ -23,7 +23,7 @@ pkgbase = dfatmo
 pkgname = dfatmo
 	pkgdesc = Analyzes the video picture and generates output data for so called 'Atmolight' controllers
 	depends = libusb
-	depends = python2
+	depends = python
 	conflicts = dfatmo-driver
 	replaces = dfatmo-driver
 

--- a/plugins/vdr-dfatmo/PKGBUILD
+++ b/plugins/vdr-dfatmo/PKGBUILD
@@ -6,12 +6,12 @@ pkgbase=dfatmo
 pkgname=('dfatmo' 'vdr-dfatmo' 'kodi-addon-dfatmo')
 pkgver=0.5.0
 _vdrapi=2.4.6
-pkgrel=6
+pkgrel=7
 epoch=1
 url="https://github.com/durchflieger/${pkgbase}"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
 license=('GPL2')
-makedepends=('libusb' 'python2' "vdr-api=${_vdrapi}" 'zip')
+makedepends=('libusb' 'python' "vdr-api=${_vdrapi}" 'zip')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/durchflieger/${pkgbase}/archive/v${pkgver}.tar.gz"
         '45-df10ch.rules'
         "50-dfatmo.conf")
@@ -20,7 +20,7 @@ md5sums=('6de5945600b0f2bea6af52ccf8f1cc32'
          'f8f2376c860c78f522e40b1afd02d38c')
 prepare() {
   cd "${srcdir}/DFAtmo-${pkgver}"
-  sed -i "s/python-config/python2-config/" Makefile
+  sed -i 's/this->ob_type/Py_TYPE(this)/' atmodriver.c
   sed -i 's/static const char \*libusb/const char \*libusb/g' df10choutputdriver.c
 }
 
@@ -39,7 +39,7 @@ package_dfatmo() {
   pkgdesc="Analyzes the video picture and generates output data for so called 'Atmolight' controllers"
   replaces=('dfatmo-driver')
   conflicts=('dfatmo-driver')
-  depends=('libusb' 'python2')
+  depends=('libusb' 'python')
 
   cd "${srcdir}/DFAtmo-${pkgver}"
   make DFATMOINSTDIR="${pkgdir}/usr" ATMODRIVER=atmodriver.so dfatmoinstall


### PR DESCRIPTION
- successfully tested with dfatmo-df10ch
- dfatmo-file and dfatmo-serial have not been tested
- kodi-addon-dfatmo is currently incompatible with kodi >= 19.0 (irrespective of the python version)