### PR TITLE
fix building vdr-streamdev-server with vdr-2.6.0

### DIFF
--- a/plugins/vdr-streamdev/.SRCINFO
+++ b/plugins/vdr-streamdev/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-streamdev
 	pkgdesc = implementation of the VTP (Video Transfer Protocol)
 	pkgver = 0.6.1.r36.ge2a9b97
-	pkgrel = 5
+	pkgrel = 6
 	url = http://projects.vdr-developer.org/projects/show/plg-streamdev
 	arch = x86_64
 	arch = i686
@@ -11,7 +11,7 @@ pkgbase = vdr-streamdev
 	license = GPL2
 	makedepends = git
 	depends = gcc-libs
-	depends = vdr-api=2.4.7
+	depends = vdr-api=2.6.0
 	source = git://projects.vdr-developer.org/vdr-plugin-streamdev.git#commit=e2a9b979d3fb92967c7a6a8221e674eb7e55c813
 	source = 50-streamdev-server.conf
 	md5sums = SKIP
@@ -29,4 +29,3 @@ pkgname = vdr-streamdev-server
 	replaces = vdr-streamdev
 	backup = etc/vdr/conf.avail/50-streamdev-server.conf
 	backup = var/lib/vdr/plugins/streamdev-server/streamdevhosts.conf
-

--- a/plugins/vdr-streamdev/PKGBUILD
+++ b/plugins/vdr-streamdev/PKGBUILD
@@ -6,8 +6,8 @@ pkgbase=vdr-streamdev
 pkgname=(vdr-streamdev-{client,server})
 pkgver=0.6.1.r36.ge2a9b97
 _gitver=e2a9b979d3fb92967c7a6a8221e674eb7e55c813
-_vdrapi=2.4.7
-pkgrel=5
+_vdrapi=2.6.0
+pkgrel=6
 pkgdesc="implementation of the VTP (Video Transfer Protocol)"
 url="http://projects.vdr-developer.org/projects/show/plg-streamdev"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
@@ -33,6 +33,11 @@ pkgver() {
   else
     printf "%s" $_last_release
   fi
+}
+
+prepare() {
+  cd "${srcdir}/vdr-plugin-$_plugname"
+  sed -i 's/cDevice::SetCurrentChannel(CurrentChannel);/cDevice::SetCurrentChannel(CurrentChannel->Number());/' server/connectionVTP.c
 }
 
 build() {

--- a/repo-make.conf
+++ b/repo-make.conf
@@ -113,7 +113,7 @@ plugins/vdr-skinsoppalusikka
 plugins/vdr-sleeptimer
 plugins/vdr-softhdcuvid
 plugins/vdr-softhddevice
-#plugins/vdr-streamdev TODO: https://www.vdr-portal.de/forum/index.php?thread/134493-plugins-vdr-2-5-4/&postID=1341076#post1341076
+plugins/vdr-streamdev
 plugins/vdr-suspendoutput
 plugins/vdr-svdrposd
 plugins/vdr-svdrpservice


### PR DESCRIPTION
Thanks for the update to v2.6.0! With this PR `vdr-streamdev-server` builds successfully and works as expected.