### PR TITLE
Updates and small dependencies rework

### DIFF
--- a/.ci/repo-make-ci.sh
+++ b/.ci/repo-make-ci.sh
@@ -125,7 +125,7 @@ if [ "$REPO_MAKE_ARCH" = "x86_64" ]; then
   PACMAN_KEYRING="archlinux"
 
   # Get name and checksum of latest bootstrap image directly from archlinux.org
-  IMAGEINFO=$(wget -q https://www.archlinux.org/iso/latest/sha1sums.txt -O - | grep bootstrap | tee "$TMPDIR/archlinux-bootstrap.sha1")
+  IMAGEINFO=$(wget -q https://www.archlinux.org/iso/latest/sha1sums.txt -O - | grep "bootstrap-$REPO_MAKE_ARCH" | tee "$TMPDIR/archlinux-bootstrap.sha1")
   IMAGENAME=${IMAGEINFO##* }
   IMAGECHECKSUM=${IMAGEINFO%% *}
   if [ "$IMAGENAME" == "$IMAGECHECKSUM" ] || [ ${#IMAGECHECKSUM} -ne 40 ]; then

--- a/plugins/vdr-live/.SRCINFO
+++ b/plugins/vdr-live/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-live
 	pkgdesc = Adds the possibility to control VDR and some of it's plugins by a web interface.
-	pkgver = 3.1.3
-	pkgrel = 3
+	pkgver = 3.1.6
+	pkgrel = 1
 	epoch = 1
 	url = https://github.com/MarkusEh/vdr-plugin-live
 	install = vdr-live.install
@@ -18,9 +18,9 @@ pkgbase = vdr-live
 	optdepends = vdr-streamdev: Stream live TV
 	optdepends = ffmpeg: Transcoding video streams
 	backup = etc/vdr/conf.avail/50-live.conf
-	source = vdr-live-3.1.3.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v3.1.3.tar.gz
+	source = vdr-live-3.1.6.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v3.1.6.tar.gz
 	source = 50-live.conf
-	sha256sums = 49bc86d3e9643f9481669f597267c422c5c5a24f4304bbabec044788c8109677
+	sha256sums = bac59c1fe034f82913f3b8c0d30ef0bbb6c60fe27095e8275c34f18ee575a7f7
 	sha256sums = a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea
 
 pkgname = vdr-live

--- a/plugins/vdr-live/PKGBUILD
+++ b/plugins/vdr-live/PKGBUILD
@@ -2,8 +2,8 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-live
-pkgver=3.1.3
-pkgrel=3
+pkgver=3.1.6
+pkgrel=1
 _vdrapi=2.6.1
 epoch=1
 pkgdesc="Adds the possibility to control VDR and some of it's plugins by a web interface."
@@ -19,7 +19,7 @@ _plugname=${pkgname//vdr-/}
 source=("$pkgname-$pkgver.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v$pkgver.tar.gz"
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('49bc86d3e9643f9481669f597267c422c5c5a24f4304bbabec044788c8109677'
+sha256sums=('8231f22d397b6cc954615304a12319fb74553aa67fbf12536b1df6727f69b8a2'
             'a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea')
 
 build() {

--- a/plugins/vdr-markad/.SRCINFO
+++ b/plugins/vdr-markad/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-markad
 	pkgdesc = Plugin to mark advertisemets in recordings and optionally auto-cut
-	pkgver = 3.0.16
-	pkgrel = 3
+	pkgver = 3.0.24
+	pkgrel = 1
 	epoch = 1
 	url = https://github.com/kfb77/vdr-plugin-markad
 	arch = x86_64
@@ -10,14 +10,18 @@ pkgbase = vdr-markad
 	arch = armv6h
 	arch = armv7h
 	license = GPL2
-	depends = ffmpeg
 	depends = vdr-api=2.6.1
+	depends = libavcodec.so
+	depends = libavfilter.so
+	depends = libavformat.so
+	depends = libavutil.so
+	depends = libswresample.so
 	backup = etc/vdr/conf.avail/50-markad.conf
-	source = vdr-markad-3.0.16.tar.gz::https://github.com/kfb77/vdr-plugin-markad/archive/v3.0.16.tar.gz
-	source = vdr-markad-logos-1.tar.bz2::https://projects.vdr-developer.org/git/vdr-plugin-markad.git/snapshot/vdr-plugin-markad-ea2e182ec798375f3830f8b794e7408576f139ad.tar.bz2
+	source = vdr-markad-3.0.24.tar.gz::https://github.com/kfb77/vdr-plugin-markad/archive/v3.0.24.tar.gz
+	source = vdr-markad-logos-1.tar.gz::https://github.com/vdr-projects/vdr-plugin-markad/archive/ea2e182ec798375f3830f8b794e7408576f139ad.tar.gz
 	source = 50-markad.conf
-	sha256sums = 1fd5dd075935e1541ec2c16d8c38d67c670f68ab6d7bb42e6c0800ee7135b325
-	sha256sums = c5316bd48ebdb58ecad8bf8de29b2b92337aa8350a4d3340e8383301d4f7719f
+	sha256sums = 422b60aa95be5b3bba5f3efffa546c82f1319378180529de8aa4309fdaa63b28
+	sha256sums = b2e58edae4899272a58c89d193089adf900e5098d57bf1fb449d4f308b61e9a8
 	sha256sums = 5b4f76d1ff31fc2aee847a070954bad1dbf00446c2e99269d9bf8331beb95e24
 
 pkgname = vdr-markad

--- a/plugins/vdr-markad/PKGBUILD
+++ b/plugins/vdr-markad/PKGBUILD
@@ -2,8 +2,8 @@
 
 # Maintainer: Manuel Reimer <manuel.reimer@gmx.de>
 pkgname=vdr-markad
-pkgver=3.0.16
-pkgrel=3
+pkgver=3.0.24
+pkgrel=1
 _logover=ea2e182ec798375f3830f8b794e7408576f139ad
 epoch=1
 _vdrapi=2.6.1
@@ -11,14 +11,14 @@ pkgdesc="Plugin to mark advertisemets in recordings and optionally auto-cut"
 url="https://github.com/kfb77/vdr-plugin-markad"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
 license=('GPL2')
-depends=('ffmpeg' "vdr-api=${_vdrapi}")
+depends=("vdr-api=${_vdrapi}" 'libavcodec.so' 'libavfilter.so' 'libavformat.so' 'libavutil.so' 'libswresample.so')
 _plugname=${pkgname//vdr-/}
 source=("$pkgname-$pkgver.tar.gz::https://github.com/kfb77/vdr-plugin-markad/archive/v$pkgver.tar.gz"
-        "$pkgname-logos-1.tar.bz2::https://projects.vdr-developer.org/git/vdr-plugin-markad.git/snapshot/vdr-plugin-markad-$_logover.tar.bz2"
+        "$pkgname-logos-1.tar.gz::https://github.com/vdr-projects/vdr-plugin-markad/archive/$_logover.tar.gz"
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('1fd5dd075935e1541ec2c16d8c38d67c670f68ab6d7bb42e6c0800ee7135b325'
-            'c5316bd48ebdb58ecad8bf8de29b2b92337aa8350a4d3340e8383301d4f7719f'
+sha256sums=('422b60aa95be5b3bba5f3efffa546c82f1319378180529de8aa4309fdaa63b28'
+            'b2e58edae4899272a58c89d193089adf900e5098d57bf1fb449d4f308b61e9a8'
             '5b4f76d1ff31fc2aee847a070954bad1dbf00446c2e99269d9bf8331beb95e24')
 
 prepare() {

--- a/plugins/vdr-mpv/.SRCINFO
+++ b/plugins/vdr-mpv/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-mpv
 	pkgdesc = mpv player plugin for VDR
-	pkgver = 1.1.1
-	pkgrel = 4
+	pkgver = 1.3.3
+	pkgrel = 1
 	url = https://github.com/ua0lnj/vdr-plugin-mpv
 	arch = x86_64
 	arch = i686
@@ -9,9 +9,9 @@ pkgbase = vdr-mpv
 	depends = mpv
 	depends = vdr-api=2.6.1
 	backup = etc/vdr/conf.avail/50-mpv.conf
-	source = vdr-mpv-1.1.1.tar.gz::https://github.com/ua0lnj/vdr-plugin-mpv/archive/v1.1.1.tar.gz
+	source = vdr-mpv-1.3.3.tar.gz::https://github.com/ua0lnj/vdr-plugin-mpv/archive/v1.3.3.tar.gz
 	source = 50-mpv.conf
-	sha256sums = ea6a4a2086f2729df400ed02193a85b646c8d6ad92fccc8430bd27bafcd1cfb0
+	sha256sums = dab3888fb5d5a32f45393a419b50930616d655ed70b598a9cbd4aedc67af3e4d
 	sha256sums = e03891f550b215efa19cdb51e133434d99b416e91f0f6e7204ffaee70287633c
 
 pkgname = vdr-mpv

--- a/plugins/vdr-mpv/PKGBUILD
+++ b/plugins/vdr-mpv/PKGBUILD
@@ -2,9 +2,9 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-mpv
-pkgver=1.1.1
+pkgver=1.3.3
 _vdrapi=2.6.1
-pkgrel=4
+pkgrel=1
 pkgdesc="mpv player plugin for VDR"
 url="https://github.com/ua0lnj/vdr-plugin-mpv"
 arch=('x86_64' 'i686')
@@ -14,7 +14,7 @@ _plugname=${pkgname//vdr-/}
 source=("$pkgname-$pkgver.tar.gz::https://github.com/ua0lnj/vdr-plugin-mpv/archive/v$pkgver.tar.gz"
         "50-${pkgname//vdr-/}.conf")
 backup=("etc/vdr/conf.avail/50-${pkgname//vdr-/}.conf")
-sha256sums=('ea6a4a2086f2729df400ed02193a85b646c8d6ad92fccc8430bd27bafcd1cfb0'
+sha256sums=('dab3888fb5d5a32f45393a419b50930616d655ed70b598a9cbd4aedc67af3e4d'
             'e03891f550b215efa19cdb51e133434d99b416e91f0f6e7204ffaee70287633c')
 
 build() {

--- a/plugins/vdr-softhdcuvid/.SRCINFO
+++ b/plugins/vdr-softhdcuvid/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-softhdcuvid
 	pkgdesc = VDR output plugin with CUDA and Opengl
 	pkgver = 3.6
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/jojo61/vdr-plugin-softhdcuvid
 	arch = x86_64
 	license = AGPL3
@@ -24,7 +24,6 @@ pkgbase = vdr-softhdcuvid
 	sha512sums = a6d038f645de6936487b18452bdda3ca17545d6168289fdd144f40e4eada37949c27a28a810108ad5e6e5cba63ee1b7c9f3891fd8ae53a5d7d0e4b3675327c58
 
 pkgname = vdr-softhdcuvid
-	depends = ffmpeg
 	depends = freeglut
 	depends = glew
 	depends = mesa
@@ -32,28 +31,37 @@ pkgname = vdr-softhdcuvid
 	depends = xcb-util-wm
 	depends = xorg-server
 	depends = nvidia>=410.48
-	depends = libplacebo>=3.120.0
+	depends = libavcodec.so
+	depends = libavutil.so
+	depends = libplacebo.so
+	depends = libswresample.so
 	optdepends = vdr-xorg: Recommended way to start X.org server together with VDR
 	backup = etc/vdr/conf.avail/50-softhdcuvid.conf
 
 pkgname = vdr-softhdvaapi
-	depends = ffmpeg
 	depends = freeglut
 	depends = glew
 	depends = mesa
 	depends = vdr-api=2.6.1
 	depends = xcb-util-wm
 	depends = xorg-server
-	depends = libplacebo>=3.120.0
+	depends = libavcodec.so
+	depends = libavfilter.so
+	depends = libavutil.so
+	depends = libplacebo.so
+	depends = libswresample.so
 	optdepends = vdr-xorg: Recommended way to start X.org server together with VDR
 	backup = etc/vdr/conf.avail/50-softhdvaapi.conf
 
 pkgname = vdr-softhddrm
-	depends = ffmpeg
 	depends = freeglut
 	depends = glew
 	depends = mesa
 	depends = vdr-api=2.6.1
 	depends = xcb-util-wm
+	depends = libavcodec.so
+	depends = libavfilter.so
+	depends = libavutil.so
+	depends = libswresample.so
 	conflicts = vdr-xorg
 	backup = etc/vdr/conf.avail/50-softhddrm.conf

--- a/plugins/vdr-softhdcuvid/PKGBUILD
+++ b/plugins/vdr-softhdcuvid/PKGBUILD
@@ -3,7 +3,7 @@ pkgbase=vdr-softhdcuvid
 pkgname=(vdr-softhdcuvid vdr-softhdvaapi vdr-softhddrm)
 pkgver=3.6
 _vdrapi=2.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc="VDR output plugin with CUDA and Opengl"
 url="https://github.com/jojo61/vdr-plugin-softhdcuvid"
 arch=('x86_64')
@@ -36,7 +36,8 @@ build() {
 }
 
 package_vdr-softhdcuvid() {
-  depends=('ffmpeg' 'freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm' 'xorg-server' 'nvidia>=410.48' 'libplacebo>=3.120.0')
+  depends=('freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm' 'xorg-server' 'nvidia>=410.48'
+           'libavcodec.so' 'libavutil.so' 'libplacebo.so' 'libswresample.so')
   optdepends=('vdr-xorg: Recommended way to start X.org server together with VDR')
   backup=("etc/vdr/conf.avail/50-$_plugname.conf")
 
@@ -48,7 +49,8 @@ package_vdr-softhdcuvid() {
 }
 
 package_vdr-softhdvaapi() {
-  depends=('ffmpeg' 'freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm' 'xorg-server' 'libplacebo>=3.120.0')
+  depends=('freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm' 'xorg-server'
+           'libavcodec.so' 'libavfilter.so' 'libavutil.so' 'libplacebo.so' 'libswresample.so')
   optdepends=('vdr-xorg: Recommended way to start X.org server together with VDR')
   backup=("etc/vdr/conf.avail/50-softhdvaapi.conf")
 
@@ -61,7 +63,8 @@ package_vdr-softhdvaapi() {
 }
 
 package_vdr-softhddrm() {
-  depends=('ffmpeg' 'freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm')
+  depends=('freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm'
+           'libavcodec.so' 'libavfilter.so' 'libavutil.so' 'libswresample.so')
   conflicts=('vdr-xorg')
   backup=("etc/vdr/conf.avail/50-softhddrm.conf")
 

--- a/plugins/vdr-softhddevice/.SRCINFO
+++ b/plugins/vdr-softhddevice/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vdr-softhddevice
 	pkgdesc = software and GPU emulated HD output device plugin for VDR
-	pkgver = 1.7.0
+	pkgver = 1.8.2
 	pkgrel = 1
 	epoch = 1
 	url = https://github.com/ua0lnj/vdr-plugin-softhddevice
@@ -10,19 +10,21 @@ pkgbase = vdr-softhddevice
 	makedepends = glm
 	makedepends = glu
 	makedepends = ffnvcodec-headers
-	depends = ffmpeg
 	depends = freeglut
 	depends = glew
 	depends = mesa
 	depends = vdr-api=2.6.1
 	depends = xcb-util-wm
 	depends = xorg-server
+	depends = libavcodec.so
+	depends = libswscale.so
+	depends = libswresample.so
 	optdepends = nvidia: Required for VDPAU decoding,
 	optdepends = vdr-xorg: Recommended way to start X.org server together with VDR
 	backup = etc/vdr/conf.avail/50-softhddevice.conf
-	source = vdr-softhddevice-1.7.0.tar.gz::https://github.com/ua0lnj/vdr-plugin-softhddevice/archive/v1.7.0.tar.gz
+	source = vdr-softhddevice-1.8.2.tar.gz::https://github.com/ua0lnj/vdr-plugin-softhddevice/archive/v1.8.2.tar.gz
 	source = 50-softhddevice.conf
-	sha256sums = 7ed4cd99c312c9845c95e6209ded312de2a258887504e97c3ded471a56ed8a3c
+	sha256sums = 8751ffb53a0ea0174faf3f0a9b81987dd5bf0cea52594c8c583d8b8bf61d016a
 	sha256sums = 889d4c19770a926f8aa6a014ff8219800a7a74c464ef0b12dcef6bb8db93e719
 
 pkgname = vdr-softhddevice

--- a/plugins/vdr-softhddevice/PKGBUILD
+++ b/plugins/vdr-softhddevice/PKGBUILD
@@ -2,7 +2,7 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-softhddevice
-pkgver=1.7.0
+pkgver=1.8.2
 epoch=1
 _vdrapi=2.6.1
 pkgrel=1
@@ -10,7 +10,8 @@ pkgdesc="software and GPU emulated HD output device plugin for VDR"
 url="https://github.com/ua0lnj/vdr-plugin-softhddevice"
 arch=('x86_64' 'i686')
 license=('AGPL3')
-depends=('ffmpeg' 'freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm' 'xorg-server')
+depends=('freeglut' 'glew' 'mesa' "vdr-api=${_vdrapi}" 'xcb-util-wm' 'xorg-server'
+         'libavcodec.so' 'libswscale.so' 'libswresample.so')
 optdepends=('nvidia: Required for VDPAU decoding',
             'vdr-xorg: Recommended way to start X.org server together with VDR')
 makedepends=('glm' 'glu' 'ffnvcodec-headers')
@@ -18,7 +19,7 @@ _plugname=${pkgname//vdr-/}
 source=("$pkgname-$pkgver.tar.gz::https://github.com/ua0lnj/vdr-plugin-softhddevice/archive/v$pkgver.tar.gz"
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('7ed4cd99c312c9845c95e6209ded312de2a258887504e97c3ded471a56ed8a3c'
+sha256sums=('8751ffb53a0ea0174faf3f0a9b81987dd5bf0cea52594c8c583d8b8bf61d016a'
             '889d4c19770a926f8aa6a014ff8219800a7a74c464ef0b12dcef6bb8db93e719')
 
 prepare() {


### PR DESCRIPTION
Aside from updates I changed how dependencies are handled for packages using `ffmpeg` and `libplacebo`. These projects evolve fast, and often the user could update the system, just to spot later that the plugin can't run cause it's linked to older library version. Therefore hardcode library version in dependencies array to prompt the warning before upgrade of the system is commenced, so the package won't end in broken state and user could raise the issue that it needs a rebuild.

The last commit is (I assume) temporary workaround of this issue https://github.com/M-Reimer/repo-make/issues/5, so the PR doesn't fail the test build.