### PR TITLE
Dvbapi updates

### DIFF
--- a/oscam/.SRCINFO
+++ b/oscam/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = oscam
 	pkgdesc = Open Source Conditional Access Module software
-	pkgver = 11532
-	pkgrel = 2
+	pkgver = 11718
+	pkgrel = 1
 	url = https://www.streamboard.tv/oscam
 	install = oscam.install
 	arch = x86_64
@@ -15,7 +15,7 @@ pkgbase = oscam
 	depends = openssl-1.1
 	depends = pcsclite
 	optdepends = ccid: PC/SC reader generic driver
-	source = oscam::svn+https://svn.streamboard.tv/oscam/trunk#revision=11532
+	source = oscam::svn+https://svn.streamboard.tv/oscam/trunk#revision=11718
 	source = oscam.service
 	source = oscam.sysuser
 	md5sums = SKIP

--- a/oscam/PKGBUILD
+++ b/oscam/PKGBUILD
@@ -2,8 +2,8 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=oscam
-pkgver=11532
-pkgrel=2
+pkgver=11718
+pkgrel=1
 pkgdesc="Open Source Conditional Access Module software"
 url='https://www.streamboard.tv/oscam'
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')

--- a/plugins/vdr-dvbapi/.SRCINFO
+++ b/plugins/vdr-dvbapi/.SRCINFO
@@ -1,19 +1,18 @@
 pkgbase = vdr-dvbapi
 	pkgdesc = A bridge between VDR and OScam.
-	pkgver = 2.2.5
-	pkgrel = 8
+	pkgver = 2.2.6
+	pkgrel = 1
 	epoch = 1
 	url = https://github.com/manio/vdr-plugin-dvbapi
 	arch = x86_64
 	arch = i686
 	license = GPL2
-	makedepends = git
 	depends = gcc-libs
 	depends = libdvbcsa
 	depends = openssl
 	depends = vdr-api=2.6.3
 	backup = etc/vdr/conf.avail/50-dvbapi.conf
-	source = git+https://github.com/manio/vdr-plugin-dvbapi.git#commit=cd1f00caa271c02641a13c541afaa9b3c0d695c1
-	sha256sums = SKIP
+	source = vdr-plugin-dvbapi-2.2.6.tar.gz::https://github.com/manio/vdr-plugin-dvbapi/archive/refs/tags/v2.2.6.tar.gz
+	sha256sums = dba435f6d9172189de4059d796d9020109997d51370e49ec0398d40ef8e08f69
 
 pkgname = vdr-dvbapi

--- a/plugins/vdr-dvbapi/PKGBUILD
+++ b/plugins/vdr-dvbapi/PKGBUILD
@@ -2,35 +2,28 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-dvbapi
-pkgver=2.2.5
+pkgver=2.2.6
 epoch=1
-_gitver=cd1f00caa271c02641a13c541afaa9b3c0d695c1
 _vdrapi=2.6.3
-pkgrel=8
+pkgrel=1
 pkgdesc="A bridge between VDR and OScam."
 url="https://github.com/manio/vdr-plugin-dvbapi"
 arch=('x86_64' 'i686')
 license=('GPL2')
 depends=('gcc-libs' 'libdvbcsa' 'openssl' "vdr-api=${_vdrapi}")
-makedepends=('git')
 _plugname=${pkgname//vdr-/}
-source=("git+${url}.git#commit=${_gitver}")
+source=("vdr-plugin-${_plugname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('SKIP')
-
-pkgver() {
-  cd "${srcdir}/vdr-plugin-${_plugname}"
-  git describe --tags | sed 's/-/_/g;s/v//'
-}
+sha256sums=('dba435f6d9172189de4059d796d9020109997d51370e49ec0398d40ef8e08f69')
 
 build() {
-  cd "${srcdir}/vdr-plugin-${_plugname}"
+  cd "${srcdir}/vdr-plugin-${_plugname}-${pkgver}"
   sed -i 's/ -fdiagnostics-color=auto//g' Makefile
   make LIBDVBCSA=1
 }
 
 package() {
-  cd "${srcdir}/vdr-plugin-${_plugname}"
+  cd "${srcdir}/vdr-plugin-${_plugname}-${pkgver}"
   make LIBDVBCSA=1 DESTDIR="$pkgdir" install
 
   mkdir -p "$pkgdir/etc/vdr/conf.avail"


### PR DESCRIPTION
Since the dvbapi plugin has new version tagged we also update oscam to latest revision, as both of them use newer dvbapi protocol to communicate.