### PR TITLE
New versions of vdr-epgsearch and vdr-live

### DIFF
--- a/plugins/vdr-epgsearch/.SRCINFO
+++ b/plugins/vdr-epgsearch/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vdr-epgsearch
 	pkgdesc = Searchtimer and replacement of the VDR program menu
-	pkgver = 2.4.1
+	pkgver = 2.4.2
 	pkgrel = 4
 	epoch = 1
 	url = https://github.com/vdr-projects/vdr-plugin-epgsearch
@@ -26,9 +26,9 @@ pkgbase = vdr-epgsearch
 	backup = var/lib/vdr/plugins/epgsearch/epgsearchmenu.conf
 	backup = var/lib/vdr/plugins/epgsearch/epgsearchupdmail-html.templ
 	backup = var/lib/vdr/plugins/epgsearch/epgsearchupdmail.templ
-	source = vdr-epgsearch-2.4.1.tar.gz::https://github.com/vdr-projects/vdr-plugin-epgsearch/archive/refs/tags/v2.4.1.tar.gz
+	source = vdr-epgsearch-2.4.2.tar.gz::https://github.com/vdr-projects/vdr-plugin-epgsearch/archive/refs/tags/v2.4.2.tar.gz
 	source = 50-epgsearch.conf
-	sha256sums = 328031a4d41275d152d1d4b80165e287ccf1b54bd37747c3f295b1cfd8badcfe
+	sha256sums = 7c0a03c22fedbc73a34220da0edf3293a903185c412d5b20fb48d72f2e4fd118
 	sha256sums = f3f8c750a0313c01a4295d2249f030ee510b2e35137b1f2cdcaa39aa440a3a88
 
 pkgname = vdr-epgsearch

--- a/plugins/vdr-epgsearch/.SRCINFO
+++ b/plugins/vdr-epgsearch/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-epgsearch
 	pkgdesc = Searchtimer and replacement of the VDR program menu
 	pkgver = 2.4.2
-	pkgrel = 4
+	pkgrel = 1
 	epoch = 1
 	url = https://github.com/vdr-projects/vdr-plugin-epgsearch
 	arch = x86_64

--- a/plugins/vdr-epgsearch/PKGBUILD
+++ b/plugins/vdr-epgsearch/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=vdr-epgsearch
 pkgver=2.4.2
 _vdrapi=2.6.3
-pkgrel=4
+pkgrel=1
 epoch=1
 pkgdesc="Searchtimer and replacement of the VDR program menu"
 url="https://github.com/vdr-projects/vdr-plugin-epgsearch"

--- a/plugins/vdr-epgsearch/PKGBUILD
+++ b/plugins/vdr-epgsearch/PKGBUILD
@@ -2,7 +2,7 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-epgsearch
-pkgver=2.4.1
+pkgver=2.4.2
 _vdrapi=2.6.3
 pkgrel=4
 epoch=1
@@ -28,7 +28,7 @@ backup=("etc/vdr/conf.avail/50-conflictcheckonly.conf"
         'var/lib/vdr/plugins/epgsearch/epgsearchupdmail-html.templ'
         'var/lib/vdr/plugins/epgsearch/epgsearchupdmail.templ')
 options=('!emptydirs')
-sha256sums=('328031a4d41275d152d1d4b80165e287ccf1b54bd37747c3f295b1cfd8badcfe'
+sha256sums=('7c0a03c22fedbc73a34220da0edf3293a903185c412d5b20fb48d72f2e4fd118'
             'f3f8c750a0313c01a4295d2249f030ee510b2e35137b1f2cdcaa39aa440a3a88')
 
 prepare() {

--- a/plugins/vdr-live/.SRCINFO
+++ b/plugins/vdr-live/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = vdr-live
 	pkgdesc = Adds the possibility to control VDR and some of it's plugins by a web interface.
 	pkgver = 3.1.11
-	pkgrel = 2
+	pkgrel = 1
 	epoch = 1
 	url = https://github.com/MarkusEh/vdr-plugin-live
 	install = vdr-live.install

--- a/plugins/vdr-live/.SRCINFO
+++ b/plugins/vdr-live/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vdr-live
 	pkgdesc = Adds the possibility to control VDR and some of it's plugins by a web interface.
-	pkgver = 3.1.8
+	pkgver = 3.1.11
 	pkgrel = 2
 	epoch = 1
 	url = https://github.com/MarkusEh/vdr-plugin-live
@@ -18,9 +18,9 @@ pkgbase = vdr-live
 	optdepends = vdr-streamdev: Stream live TV
 	optdepends = ffmpeg: Transcoding video streams
 	backup = etc/vdr/conf.avail/50-live.conf
-	source = vdr-live-3.1.8.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v3.1.8.tar.gz
+	source = vdr-live-3.1.11.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v3.1.11.tar.gz
 	source = 50-live.conf
-	sha256sums = b7f50e68336964d2872ec5f06c3a29106ef5a2c314eadc653fde4f2cd9efabb2
+	sha256sums = 4e4850220e391653c828e4212438e9511f1461c762bb6af2f2d87c327a1c35d8
 	sha256sums = a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea
 
 pkgname = vdr-live

--- a/plugins/vdr-live/.SRCINFO
+++ b/plugins/vdr-live/.SRCINFO
@@ -20,7 +20,7 @@ pkgbase = vdr-live
 	backup = etc/vdr/conf.avail/50-live.conf
 	source = vdr-live-3.1.11.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v3.1.11.tar.gz
 	source = 50-live.conf
-	sha256sums = 4e4850220e391653c828e4212438e9511f1461c762bb6af2f2d87c327a1c35d8
+	sha256sums = 8a6bcdefb8a84be835ff20fe6bca02b691f2cb606898b870c728138f16dbc778
 	sha256sums = a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea
 
 pkgname = vdr-live

--- a/plugins/vdr-live/PKGBUILD
+++ b/plugins/vdr-live/PKGBUILD
@@ -19,7 +19,7 @@ _plugname=${pkgname//vdr-/}
 source=("$pkgname-$pkgver.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v$pkgver.tar.gz"
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('4e4850220e391653c828e4212438e9511f1461c762bb6af2f2d87c327a1c35d8'
+sha256sums=('8a6bcdefb8a84be835ff20fe6bca02b691f2cb606898b870c728138f16dbc778'
             'a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea')
 
 build() {

--- a/plugins/vdr-live/PKGBUILD
+++ b/plugins/vdr-live/PKGBUILD
@@ -2,7 +2,7 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-live
-pkgver=3.1.8
+pkgver=3.1.11
 pkgrel=2
 _vdrapi=2.6.3
 epoch=1
@@ -19,7 +19,7 @@ _plugname=${pkgname//vdr-/}
 source=("$pkgname-$pkgver.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v$pkgver.tar.gz"
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('b7f50e68336964d2872ec5f06c3a29106ef5a2c314eadc653fde4f2cd9efabb2'
+sha256sums=('4e4850220e391653c828e4212438e9511f1461c762bb6af2f2d87c327a1c35d8'
             'a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea')
 
 build() {

--- a/plugins/vdr-live/PKGBUILD
+++ b/plugins/vdr-live/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-live
 pkgver=3.1.11
-pkgrel=2
+pkgrel=1
 _vdrapi=2.6.3
 epoch=1
 pkgdesc="Adds the possibility to control VDR and some of it's plugins by a web interface."


### PR DESCRIPTION
vdr-epgsearch -> 2.4.2
[Update version](https://github.com/vdr-projects/vdr-plugin-epgsearch/commit/7f7f9f6569bd50946166fe23463879c16378b651)

vdr-live -> 3.1.11
[Makefile: fix problem building with make-4.4](https://github.com/MarkusEh/vdr-plugin-live/commit/a3671a5effd4933904933a918211c20fad0c2b85)