### PR TITLE
skip building the atmodriver needed for kodi

### DIFF
--- a/plugins/vdr-dfatmo/.SRCINFO
+++ b/plugins/vdr-dfatmo/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dfatmo
 	pkgver = 0.5.0
-	pkgrel = 14
+	pkgrel = 15
 	epoch = 1
 	url = https://github.com/durchflieger/dfatmo
 	arch = x86_64
@@ -10,8 +10,7 @@ pkgbase = dfatmo
 	arch = armv7h
 	license = GPL2
 	makedepends = libusb
-	makedepends = python
-	makedepends = vdr-api=2.6.7
+	makedepends = vdr-api=5
 	makedepends = zip
 	source = dfatmo-0.5.0.tar.gz::https://github.com/durchflieger/dfatmo/archive/v0.5.0.tar.gz
 	source = 45-df10ch.rules
@@ -23,7 +22,6 @@ pkgbase = dfatmo
 pkgname = dfatmo
 	pkgdesc = Analyzes the video picture and generates output data for so called 'Atmolight' controllers
 	depends = libusb
-	depends = python
 	conflicts = dfatmo-driver
 	replaces = dfatmo-driver
 
@@ -31,14 +29,5 @@ pkgname = vdr-dfatmo
 	pkgdesc = VDR plugin to drive a colored back lighting for TVs
 	depends = gcc-libs
 	depends = dfatmo
-	depends = vdr-api=2.6.7
+	depends = vdr-api=5
 	backup = etc/vdr/conf.avail/50-.conf
-
-pkgname = kodi-addon-dfatmo
-	pkgdesc = VDR plugin to drive a colored back lighting for TVs
-	arch = any
-	depends = dfatmo
-	depends = python
-	depends = kodi
-	conflicts = xbmc-addon-dfatmo
-	replaces = xbmc-addon-dfatmo

--- a/plugins/vdr-dfatmo/PKGBUILD
+++ b/plugins/vdr-dfatmo/PKGBUILD
@@ -3,24 +3,24 @@
 # Maintainer: Ole Ernst <olebowle[at]gmx[dot]com>
 # Contributor: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgbase=dfatmo
-pkgname=('dfatmo' 'vdr-dfatmo' 'kodi-addon-dfatmo')
+pkgname=('dfatmo' 'vdr-dfatmo')
 pkgver=0.5.0
-_vdrapi=2.6.7
-pkgrel=14
+_vdrapi=5
+pkgrel=15
 epoch=1
 url="https://github.com/durchflieger/${pkgbase}"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
 license=('GPL2')
-makedepends=('libusb' 'python' "vdr-api=${_vdrapi}" 'zip')
+makedepends=('libusb' "vdr-api=${_vdrapi}" 'zip')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/durchflieger/${pkgbase}/archive/v${pkgver}.tar.gz"
         '45-df10ch.rules'
         "50-dfatmo.conf")
 md5sums=('6de5945600b0f2bea6af52ccf8f1cc32'
          'c5e0bf17e88febc7e86c7e435f5eea5f'
          'f8f2376c860c78f522e40b1afd02d38c')
+
 prepare() {
   cd "${srcdir}/DFAtmo-${pkgver}"
-  sed -i 's/this->ob_type/Py_TYPE(this)/' atmodriver.c
   sed -i 's/static const char \*libusb/const char \*libusb/g' df10choutputdriver.c
 }
 
@@ -29,7 +29,7 @@ build() {
 
   #Compile dfatmo
   CFLAGS+=' -fPIC'
-  make DFATMOINSTDIR='/usr' ATMODRIVER=atmodriver.so
+  make DFATMOINSTDIR='/usr' ATMODRIVER=
 
   #Compile vdr plugin
   make DFATMOINSTDIR='/usr' vdrplugin
@@ -39,10 +39,10 @@ package_dfatmo() {
   pkgdesc="Analyzes the video picture and generates output data for so called 'Atmolight' controllers"
   replaces=('dfatmo-driver')
   conflicts=('dfatmo-driver')
-  depends=('libusb' 'python')
+  depends=('libusb')
 
   cd "${srcdir}/DFAtmo-${pkgver}"
-  make DFATMOINSTDIR="${pkgdir}/usr" ATMODRIVER=atmodriver.so dfatmoinstall
+  make DFATMOINSTDIR="${pkgdir}/usr" ATMODRIVER= dfatmoinstall
 }
 
 package_vdr-dfatmo() {
@@ -56,15 +56,4 @@ package_vdr-dfatmo() {
   install -Dm644 "${srcdir}/45-df10ch.rules" "${pkgdir}/usr/lib/udev/rules.d/45-df10ch.rules"
 
   install -Dm644 "$srcdir/50-$_plugname.conf" "$pkgdir/etc/vdr/conf.avail/50-$_plugname.conf"
-}
-
-package_kodi-addon-dfatmo() {
-  pkgdesc="VDR plugin to drive a colored back lighting for TVs"
-  arch=('any')
-  replaces=('xbmc-addon-dfatmo')
-  conflicts=('xbmc-addon-dfatmo')
-  depends=('dfatmo' 'python' 'kodi')
-
-  cd "${srcdir}/DFAtmo-${pkgver}"
-  make XBMCDESTDIR="$pkgdir/usr/share/kodi/addons/script.dfatmo" xbmcinstall
 }

--- a/repo-make.conf
+++ b/repo-make.conf
@@ -61,7 +61,7 @@ plugins/vdr-cinebars
 plugins/vdr-dbus2vdr
 plugins/vdr-ddci2
 plugins/vdr-devstatus
-#plugins/vdr-dfatmo Incompatible with VDR 2.7.3
+plugins/vdr-dfatmo
 plugins/vdr-dummydevice
 plugins/vdr-duplicates
 plugins/vdr-dvbapi


### PR DESCRIPTION
* which is already broken for a long time
* the important bits are the output drivers and the vdr plugin

This patchset does compile, but has not been tested yet. The idea is to avoid additional effort by other developers. I will test the branch in roughly one week.