### PR TITLE
cxxtools fix and vdr-live 3.5.0 update 

### DIFF
--- a/deps/cxxtools/.SRCINFO
+++ b/deps/cxxtools/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cxxtools
 	pkgdesc = Collection of general-purpose C++ classes
 	pkgver = 3.0
-	pkgrel = 3
+	pkgrel = 4
 	url = http://www.tntnet.org
 	arch = x86_64
 	arch = i686
@@ -16,8 +16,10 @@ pkgbase = cxxtools
 	source = cxxtools-3.0_git.tar.gz::https://github.com/maekitalo/cxxtools/archive/refs/tags/V3.0.tar.gz
 	source = cxxtools-char-trivial-class.patch::https://github.com/maekitalo/cxxtools/commit/b773c01fc13d2ae67abc0839888e383be23562fd.patch
 	source = cxxtools-add-missing-time-h.patch::https://github.com/maekitalo/cxxtools/commit/6e1439a108ce3892428e95f341f2d23ae32a590e.patch
+	source = cxxtools-fix-crash-in-cxxtools-connectable.patch::https://github.com/maekitalo/cxxtools/commit/7e87a946ed0551360e4afef560f963485e3a9e8c.patch
 	sha256sums = c48758af8c8bf993a45492fdd8acaf1109357f1c574810e353d3103277b4296b
 	sha256sums = 57f2e6c037f645a93f8979b923491ea3e996ee87ceebf790177f2b4e902d51d9
 	sha256sums = 870e70768395d7037476d804936e40400541e05ff0eedff0b2579648bb74c98e
+	sha256sums = 68b2f2324ea1d90fee54b6839e80f53c6971e25dd195d9531a4aa0326b502247
 
 pkgname = cxxtools

--- a/deps/cxxtools/PKGBUILD
+++ b/deps/cxxtools/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=cxxtools
 pkgver=3.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Collection of general-purpose C++ classes"
 url="http://www.tntnet.org"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h')
@@ -11,16 +11,19 @@ license=('LGPL-2.1-or-later')
 depends=('bash' 'gcc-libs' 'libnsl' 'openssl')
 source=("$pkgname-${pkgver}_git.tar.gz::https://github.com/maekitalo/cxxtools/archive/refs/tags/V$pkgver.tar.gz"
         "$pkgname-char-trivial-class.patch::https://github.com/maekitalo/cxxtools/commit/b773c01fc13d2ae67abc0839888e383be23562fd.patch"
-        "$pkgname-add-missing-time-h.patch::https://github.com/maekitalo/cxxtools/commit/6e1439a108ce3892428e95f341f2d23ae32a590e.patch")
+        "$pkgname-add-missing-time-h.patch::https://github.com/maekitalo/cxxtools/commit/6e1439a108ce3892428e95f341f2d23ae32a590e.patch"
+        "$pkgname-fix-crash-in-cxxtools-connectable.patch::https://github.com/maekitalo/cxxtools/commit/7e87a946ed0551360e4afef560f963485e3a9e8c.patch")
 sha256sums=('c48758af8c8bf993a45492fdd8acaf1109357f1c574810e353d3103277b4296b'
             '57f2e6c037f645a93f8979b923491ea3e996ee87ceebf790177f2b4e902d51d9'
-            '870e70768395d7037476d804936e40400541e05ff0eedff0b2579648bb74c98e')
+            '870e70768395d7037476d804936e40400541e05ff0eedff0b2579648bb74c98e'
+            '68b2f2324ea1d90fee54b6839e80f53c6971e25dd195d9531a4aa0326b502247')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
 
   patch -p1 -i "$srcdir/$pkgname-char-trivial-class.patch"
   patch -p1 -i "$srcdir/$pkgname-add-missing-time-h.patch"
+  patch -p1 -i "$srcdir/$pkgname-fix-crash-in-cxxtools-connectable.patch"
 }
 
 build() {

--- a/plugins/vdr-live/.SRCINFO
+++ b/plugins/vdr-live/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vdr-live
 	pkgdesc = Adds the possibility to control VDR and some of it's plugins by a web interface.
-	pkgver = 3.4.2
+	pkgver = 3.5.0
 	pkgrel = 1
 	epoch = 1
 	url = https://github.com/MarkusEh/vdr-plugin-live
@@ -18,9 +18,9 @@ pkgbase = vdr-live
 	optdepends = vdr-streamdev: Stream live TV
 	optdepends = ffmpeg: Transcoding video streams
 	backup = etc/vdr/conf.avail/50-live.conf
-	source = vdr-live-3.4.2.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v3.4.2.tar.gz
+	source = vdr-live-3.5.0.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v3.5.0.tar.gz
 	source = 50-live.conf
-	sha256sums = 83ffd58472dab4a2b51c7dda8541c2ff1c16938264ba0e243621aac49ccfc797
+	sha256sums = 8b0af04df2d153025aaa18c7906babe2d0f6b38eca610f6c9977a5a675cd1929
 	sha256sums = a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea
 
 pkgname = vdr-live

--- a/plugins/vdr-live/PKGBUILD
+++ b/plugins/vdr-live/PKGBUILD
@@ -2,7 +2,7 @@
 
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=vdr-live
-pkgver=3.4.2
+pkgver=3.5.0
 pkgrel=1
 _vdrapi=6
 epoch=1
@@ -19,7 +19,7 @@ _plugname=${pkgname//vdr-/}
 source=("$pkgname-$pkgver.tar.gz::https://github.com/MarkusEh/vdr-plugin-live/archive/v$pkgver.tar.gz"
         "50-$_plugname.conf")
 backup=("etc/vdr/conf.avail/50-$_plugname.conf")
-sha256sums=('83ffd58472dab4a2b51c7dda8541c2ff1c16938264ba0e243621aac49ccfc797'
+sha256sums=('8b0af04df2d153025aaa18c7906babe2d0f6b38eca610f6c9977a5a675cd1929'
             'a14466937a4c618341ca3120bf353ca5b207dda0aca3b605532d3500415d7fea')
 
 build() {


### PR DESCRIPTION
In my environment, vdr-live crashed every time I reloaded the website. 
After I patched cxxtools, it seems to run stable again.

To be on the safe side, I also updated vdr-live to version 3.5.0.

Patch: [fix for possible crash in cxxtools::Connectable](https://github.com/maekitalo/cxxtools/commit/7e87a946ed0551360e4afef560f963485e3a9e8c)