### PR TITLE
cxxtools: C++20 compatibility

### DIFF
--- a/deps/cxxtools/.SRCINFO
+++ b/deps/cxxtools/.SRCINFO
@@ -1,8 +1,8 @@
 pkgbase = cxxtools
 	pkgdesc = Collection of general-purpose C++ classes
 	pkgver = 3.0
-	pkgrel = 4
-	url = http://www.tntnet.org
+	pkgrel = 5
+	url = https://github.com/maekitalo/cxxtools
 	arch = x86_64
 	arch = i686
 	arch = arm
@@ -18,9 +18,11 @@ pkgbase = cxxtools
 	source = cxxtools-char-trivial-class.patch::https://github.com/maekitalo/cxxtools/commit/b773c01fc13d2ae67abc0839888e383be23562fd.patch
 	source = cxxtools-add-missing-time-h.patch::https://github.com/maekitalo/cxxtools/commit/6e1439a108ce3892428e95f341f2d23ae32a590e.patch
 	source = cxxtools-fix-crash-in-cxxtools-connectable.patch::https://github.com/maekitalo/cxxtools/commit/7e87a946ed0551360e4afef560f963485e3a9e8c.patch
+	source = cxxtools-fix-for-c++20.patch
 	sha256sums = c48758af8c8bf993a45492fdd8acaf1109357f1c574810e353d3103277b4296b
 	sha256sums = 57f2e6c037f645a93f8979b923491ea3e996ee87ceebf790177f2b4e902d51d9
 	sha256sums = 870e70768395d7037476d804936e40400541e05ff0eedff0b2579648bb74c98e
 	sha256sums = 68b2f2324ea1d90fee54b6839e80f53c6971e25dd195d9531a4aa0326b502247
+	sha256sums = beb785ccb1036b5148f7b5bac0505213fc61e433b2e9593fdf62a6a905e1f3c7
 
 pkgname = cxxtools

--- a/deps/cxxtools/PKGBUILD
+++ b/deps/cxxtools/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Christopher Reimer <mail+vdr4arch[at]c-reimer[dot]de>
 pkgname=cxxtools
 pkgver=3.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Collection of general-purpose C++ classes"
 url="https://github.com/maekitalo/cxxtools"
 arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h' 'aarch64')
@@ -12,11 +12,13 @@ depends=('bash' 'gcc-libs' 'libnsl' 'openssl')
 source=("$pkgname-${pkgver}_git.tar.gz::https://github.com/maekitalo/cxxtools/archive/refs/tags/V$pkgver.tar.gz"
         "$pkgname-char-trivial-class.patch::https://github.com/maekitalo/cxxtools/commit/b773c01fc13d2ae67abc0839888e383be23562fd.patch"
         "$pkgname-add-missing-time-h.patch::https://github.com/maekitalo/cxxtools/commit/6e1439a108ce3892428e95f341f2d23ae32a590e.patch"
-        "$pkgname-fix-crash-in-cxxtools-connectable.patch::https://github.com/maekitalo/cxxtools/commit/7e87a946ed0551360e4afef560f963485e3a9e8c.patch")
+        "$pkgname-fix-crash-in-cxxtools-connectable.patch::https://github.com/maekitalo/cxxtools/commit/7e87a946ed0551360e4afef560f963485e3a9e8c.patch"
+        "$pkgname-fix-for-c++20.patch")
 sha256sums=('c48758af8c8bf993a45492fdd8acaf1109357f1c574810e353d3103277b4296b'
             '57f2e6c037f645a93f8979b923491ea3e996ee87ceebf790177f2b4e902d51d9'
             '870e70768395d7037476d804936e40400541e05ff0eedff0b2579648bb74c98e'
-            '68b2f2324ea1d90fee54b6839e80f53c6971e25dd195d9531a4aa0326b502247')
+            '68b2f2324ea1d90fee54b6839e80f53c6971e25dd195d9531a4aa0326b502247'
+            'beb785ccb1036b5148f7b5bac0505213fc61e433b2e9593fdf62a6a905e1f3c7')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}"
@@ -24,6 +26,8 @@ prepare() {
   patch -p1 -i "$srcdir/$pkgname-char-trivial-class.patch"
   patch -p1 -i "$srcdir/$pkgname-add-missing-time-h.patch"
   patch -p1 -i "$srcdir/$pkgname-fix-crash-in-cxxtools-connectable.patch"
+  # The patch is based on “https://github.com/maekitalo/cxxtools/commit/354ddfecd33067d8aac339437defdcf0b8c32b68”
+  patch -p1 -i "$srcdir/$pkgname-fix-for-c++20.patch"
 }
 
 build() {

--- a/deps/cxxtools/cxxtools-fix-for-c++20.patch
+++ b/deps/cxxtools/cxxtools-fix-for-c++20.patch
@@ -1,0 +1,53 @@
+--- cxxtools-3.0.orig/include/cxxtools/string.h	2020-06-03 11:29:15.000000000 +0200
++++ cxxtools-3.0/include/cxxtools/string.h	2026-05-09 21:42:01.141329372 +0200
+@@ -51,10 +51,10 @@
+         typedef char_traits< cxxtools::Char > traits_type;
+         typedef std::allocator<cxxtools::Char> allocator_type;
+         typedef allocator_type::difference_type difference_type;
+-        typedef allocator_type::reference reference;
+-        typedef allocator_type::const_reference const_reference;
+-        typedef allocator_type::pointer pointer;
+-        typedef allocator_type::const_pointer const_pointer;
++        typedef value_type& reference;
++        typedef const value_type& const_reference;
++        typedef value_type* pointer;
++        typedef const value_type* const_pointer;
+         typedef value_type* iterator;
+         typedef const value_type* const_iterator;
+ 
+diff '--color=auto' -Naur cxxtools-3.0.orig/src/charmapcodec.cpp cxxtools-3.0/src/charmapcodec.cpp
+--- cxxtools-3.0.orig/src/charmapcodec.cpp	2020-06-03 11:29:15.000000000 +0200
++++ cxxtools-3.0/src/charmapcodec.cpp	2026-05-09 22:22:02.301270065 +0200
+@@ -82,7 +82,7 @@
+     while (fromNext < fromEnd && toNext < toEnd)
+     {
+         *toNext = toChar(_charMap, *fromNext);
+-        log_debug(fromNext->value() << " => " << static_cast<unsigned>(static_cast<unsigned char>(*toNext)));
++        log_debug(static_cast<unsigned>(fromNext->value()) << " => " << static_cast<unsigned>(static_cast<unsigned char>(*toNext)));
+         ++fromNext;
+         ++toNext;
+     }
+diff '--color=auto' -Naur cxxtools-3.0.orig/src/log.cpp cxxtools-3.0/src/log.cpp
+--- cxxtools-3.0.orig/src/log.cpp	2020-06-03 11:29:15.000000000 +0200
++++ cxxtools-3.0/src/log.cpp	2026-05-09 22:23:08.398255933 +0200
+@@ -621,7 +621,7 @@
+     Logger::log_level_type logFlag2logLevel(Logger::log_flag_type flag)
+     {
+       if (flag == Logger::LOG_TRACE)
+-        return static_cast<Logger::log_level_type>(Logger::LOG_LEVEL_DEBUG | Logger::LOG_TRACE);
++        return static_cast<Logger::log_level_type>(Logger::LOG_LEVEL_DEBUG | static_cast<Logger::log_level_type>(Logger::LOG_TRACE));
+       return static_cast<Logger::log_level_type>((flag << 1) - 1);
+     }
+ 
+@@ -733,9 +733,9 @@
+       {
+         Logger::log_flag_type r = str2logflag(level.c_str() + 1);
+         if (r == 0)
+-          return Logger::LOG_LEVEL_DEBUG | Logger::LOG_TRACE;
++          return Logger::LOG_LEVEL_DEBUG | static_cast<Logger::log_level_type>(Logger::LOG_TRACE);
+ 
+-        return logFlag2logLevel(r) | Logger::LOG_TRACE;
++        return logFlag2logLevel(r) | static_cast<Logger::log_level_type>(Logger::LOG_TRACE);
+       }
+ 
+       // case "everything below level":


### PR DESCRIPTION
### Description:
Fixes the compilation failure by addressing the removal of `std::allocator` typedefs in C++20.

### Changes:
-  Added `cxxtools-fix-for-c++20.patch`
-  Updated `PKGBUILD` & `.SRCINFO`

### Reference:
Patch based on the upstream commit: [maekitalo/cxxtools@354ddfe](https://github.com/maekitalo/cxxtools/commit/354ddfecd33067d8aac339437defdcf0b8c32b68)